### PR TITLE
ns macro usage clean up

### DIFF
--- a/src/datomic_test/core.clj
+++ b/src/datomic_test/core.clj
@@ -1,8 +1,8 @@
 (ns datomic-test.core
+  (:refer-clojure :exclude [print update get ])
   (:require [clojure.tools.cli :refer [parse-opts]])
-  (:gen-class))
-
-(use '[datomic-test.document :as doc])
+  (:gen-class)
+  (:use [datomic-test.document :as doc]))
 
 (def cli-options
   ;; An option with a required argument
@@ -19,6 +19,7 @@
 
 (defn run []
   (let [conn (doc/create-db "datomic:mem://foo")]
+    
     ;; create our first version of "foo" with two entries
     (doc/update conn "foo"
                  [{:name "bar" :value (.getBytes "baz")}

--- a/src/datomic_test/document.clj
+++ b/src/datomic_test/document.clj
@@ -1,9 +1,8 @@
 (ns datomic-test.document
   (:refer-clojure :exclude [print update get ])
-  (:require  [datomic.api :refer [q db] :as d])
-  (:use datomic-test.schema)
-  (:use clojure.pprint)
-  )
+  (:require  [datomic.api :refer [q db] :as d]
+             [datomic-test.schema :refer :all]
+             [clojure.pprint :refer :all]))
 
 (defn create-db [uri]
   (d/create-database uri)

--- a/src/datomic_test/document.clj
+++ b/src/datomic_test/document.clj
@@ -1,8 +1,9 @@
-(ns datomic-test.document)
-
-(use '[datomic.api :only [q db] :as d])
-(use 'datomic-test.schema)
-(use 'clojure.pprint)
+(ns datomic-test.document
+  (:refer-clojure :exclude [print update get ])
+  (:require  [datomic.api :refer [q db] :as d])
+  (:use datomic-test.schema)
+  (:use clojure.pprint)
+  )
 
 (defn create-db [uri]
   (d/create-database uri)

--- a/src/datomic_test/schema.clj
+++ b/src/datomic_test/schema.clj
@@ -1,6 +1,6 @@
-(ns datomic-test.schema)
-
-(use '[datomic.api :only [q db] :as d])
+(ns datomic-test.schema
+  (:require [datomic.api :refer [q db] :as d])
+  )
 
 ;;------------------------------------------------------
 ;; define our transaction functions


### PR DESCRIPTION
I added explicit refer-clojure :exclude clauses which is the only way to handle the conflicts if you use the ns macro (well, besides renaming stuff).
